### PR TITLE
remove dependency on cover for `util-v6.1.1` branch

### DIFF
--- a/alexis-util/info.rkt
+++ b/alexis-util/info.rkt
@@ -13,5 +13,4 @@
     "scribble-lib"
     "racket-doc"
     "typed-racket-doc"
-    "sandbox-lib"
-    "cover"))
+    "sandbox-lib"))


### PR DESCRIPTION
Since coverage for this branch was disabled in this commit:
https://github.com/lexi-lambda/racket-alexis/commit/7b8b9ea08ae9e4b4b8f252e0f50abb00d264028c

Fixes issue #7 for the `util-v6.1.1` branch.
