### PR TITLE
correct package version

### DIFF
--- a/alexis-multicast/info.rkt
+++ b/alexis-multicast/info.rkt
@@ -3,7 +3,7 @@
 (define collection 'multi)
 
 (define name "alexis-multicast")
-(define version "0.1.0")
+(define version "0.1")
 
 (define deps
   '("base"

--- a/alexis-util/info.rkt
+++ b/alexis-util/info.rkt
@@ -3,7 +3,7 @@
 (define collection 'multi)
 
 (define name "alexis-util")
-(define version "0.1.0")
+(define version "0.1")
 
 (define deps
   '("base"


### PR DESCRIPTION
0.1.0 is not a Racket package version, and recent Racket actually checks this constraint (failing CI builds, for example). The correct spelling is 0.1 or 0.1.[non-zero-number].

- https://docs.racket-lang.org/version/index.html#%28def._%28%28lib._version%2Futils..rkt%29._valid-version~3f%29%29
- https://docs.racket-lang.org/pkg/Package_Concepts.html#%28tech._version%29